### PR TITLE
Fix/pressure logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 Manifest.toml
+
+.vscode/
+*.log

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Two example notebooks are available to help you get started with WaterLily, they
 Below we provide a list of all the examples available
 
 #### 2D
-- [2D flow around a circle](examples/TwoD_Circle.jl)
+- [2D flow around a circle (also demo how to log pressure solver)](examples/TwoD_Circle.jl)
 - [2D flow around a circle with periodic boundary conditions](examples/TwoD_CirclePeriodicBC.jl)
 - [2D flow around a circle in 1DOF vortex-induced-vibration](examples/TwoD_CircleVIV.jl)
 - [2D flow around a flapping plate](examples/TwoD_Hover.jl)

--- a/examples/ThreeD_TaylorGreenVortex.jl
+++ b/examples/ThreeD_TaylorGreenVortex.jl
@@ -15,7 +15,7 @@ end
 
 # Initialize CUDA simulation
 # using CUDA
-sim = TGV()#mem=CUarray);
+sim = TGV()#mem=CUDA.CuArray);
 
 # Create a video using Makie
 dat = sim.flow.σ[inside(sim.flow.σ)] |> Array; # CPU buffer array

--- a/examples/TwoD_Circle.jl
+++ b/examples/TwoD_Circle.jl
@@ -1,12 +1,28 @@
 using WaterLily
 include("../src/TwoD_plots.jl")
 
-function circle(n,m;Re=250,U=1)
+cID = "2DCircle"
+
+function circle(n,m;Re=250,U=1,mem=Array)
     radius, center = m/8, m/2
     body = AutoBody((x,t)->√sum(abs2, x .- center) - radius)
-    Simulation((n,m), (U,0), radius; ν=U*radius/Re, body)
+    Simulation((n,m), (U,0), radius; ν=U*radius/Re, body, mem)
 end
 
-# Initialize and run
-sim = circle(3*2^6,2^7)
+# Initialize the simulation with GPU Array
+using CUDA
+sim = circle(3*2^6,2^7; mem=CuArray);
+
+WaterLily.logger(cID) # Log the residual of pressure solver
+#= NOTE: 
+If you want to log residuals during a GPU simulation, it's better to include the following line. 
+Otherwise, Julia will generate excessive debugging messages, which can significantly slow down the simulation. 
+=#
+using Logging; disable_logging(Logging.Debug)
+
+# Run the simulation
 sim_gif!(sim,duration=10,clims=(-5,5),plotbody=true)
+
+# Remember to call Plots package (already done in Line 2). This will let WaterLily
+# knows you want to plot sth like residual and will compile the funciton for you.
+plot_logger("$(cID).log")

--- a/examples/TwoD_Circle.jl
+++ b/examples/TwoD_Circle.jl
@@ -1,5 +1,5 @@
 using WaterLily
-include("../src/TwoD_plots.jl")
+using Plots
 
 cID = "2DCircle"
 
@@ -25,4 +25,5 @@ sim_gif!(sim,duration=10,clims=(-5,5),plotbody=true)
 
 # Remember to call Plots package (already done in Line 2). This will let WaterLily
 # knows you want to plot sth like residual and will compile the funciton for you.
+# NOTE: Comment out this line if you want to see gif animation!
 plot_logger("$(cID).log")


### PR DESCRIPTION
Logging pressure during GPU simulations without proper handling results in excessive debugging output (lowest logging level). This fix disables debug logging to address the issue without enforcing changes directly in WaterLily.jl.

This update is noteworthy for users interested in pressure logging, and it also serves as a useful example for this feature.