### PR TITLE
Damp LES sphere grid-scale streaks with a cds+quick blend

### DIFF
--- a/examples/ThreeD_SphereLESBiotSavart.jl
+++ b/examples/ThreeD_SphereLESBiotSavart.jl
@@ -10,12 +10,6 @@ arg_value(arg, args) = split(args[iarg(arg, args)], "=")[end]
 metaparse(x) = eval(Meta.parse(x))
 # SGS model
 smagorinsky(I::CartesianIndex{m} where m; S, Cs, Δ) = @views (Cs*Δ)^2*sqrt(2dot(S[I,:,:],S[I,:,:])) # Smagorinsky-Lilly SGS model
-# Convective scheme: energy-conserving `cds` base + a small upwind (`quick`) mixture
-# `cds` alone is non-dissipative and Smagorinsky νₜ∝|S|≈0 in the irrotational freestream, so grid-scale
-# noise is never damped and advects to the sphere as streaks.
-# C_blend>0 adds a strain-independent grid-scale dissipation that removes them. 0 ⇒ pure cds.
-C_blend = 1/10
-cds_blend(u,c,d) = (1-C_blend)*cds(u,c,d) + C_blend*quick(u,c,d)
 # I/O
 function save_sim(sim, meanflow, force, t)
     t_str = @sprintf("%i", sim_time(sim))
@@ -93,7 +87,13 @@ m = 3*2^p
 R = m÷3
 U = 1
 udf = explicit_sgs ? sgs! : nothing
-λ = explicit_sgs ? cds : quick
+# Convective scheme: energy-conserving `cds` base + a small upwind (`quick`) mixture
+# `cds` alone is non-dissipative and Smagorinsky νₜ∝|S|≈0 in the irrotational freestream, so grid-scale
+# noise is never damped and advects to the sphere as streaks.
+# C_blend>0 adds a strain-independent grid-scale dissipation that removes them. 0 ⇒ pure cds.
+const C_blend = T(0.1)
+cds_blend(u,c,d) = (1-C_blend)*cds(u,c,d) + C_blend*quick(u,c,d)
+λ = explicit_sgs ? cds_blend : quick
 Cs = T(0.17) # Smagorinsky constant
 Δ = sqrt(1^2 + 1^2 + 1^2) |> T # Filter width
 

--- a/examples/ThreeD_SphereLESBiotSavart.jl
+++ b/examples/ThreeD_SphereLESBiotSavart.jl
@@ -10,6 +10,12 @@ arg_value(arg, args) = split(args[iarg(arg, args)], "=")[end]
 metaparse(x) = eval(Meta.parse(x))
 # SGS model
 smagorinsky(I::CartesianIndex{m} where m; S, Cs, Δ) = @views (Cs*Δ)^2*sqrt(2dot(S[I,:,:],S[I,:,:])) # Smagorinsky-Lilly SGS model
+# Convective scheme: energy-conserving `cds` base + a small upwind (`quick`) mixture
+# `cds` alone is non-dissipative and Smagorinsky νₜ∝|S|≈0 in the irrotational freestream, so grid-scale
+# noise is never damped and advects to the sphere as streaks.
+# C_blend>0 adds a strain-independent grid-scale dissipation that removes them. 0 ⇒ pure cds.
+C_blend = 1/10
+cds_blend(u,c,d) = (1-C_blend)*cds(u,c,d) + C_blend*quick(u,c,d)
 # I/O
 function save_sim(sim, meanflow, force, t)
     t_str = @sprintf("%i", sim_time(sim))
@@ -130,7 +136,7 @@ viz!(sim) # 3D
 viz!(sim; d=2) # 2D
 # Run and visualize
 S = zeros(T, size(sim.flow.p)..., ndims(sim.flow.p), ndims(sim.flow.p)) |> mem
-viz!(sim;duration=10,remeasure=false,λ,udf,udf_kwargs=(:S=>S,:νₜ=>smagorinsky,:Cs=>Cs,:Δ=>Δ))
+viz!(sim;duration=10,remeasure=false,λ=cds_blend,udf,udf_kwargs=(:S=>S,:νₜ=>smagorinsky,:Cs=>Cs,:Δ=>Δ))
 
 # Visualize the meanflow
 viz!(sim, meanflow.U[:,:,:,1]; d=2, levels=20)


### PR DESCRIPTION
### Problem
`ThreeD_SphereLESBiotSavart` runs the energy-conserving `cds` scheme with a Smagorinsky SGS model. `cds` is non-dissipative, and Smagorinsky's eddy viscosity `νₜ ∝ |S|` is ≈0 in the irrotational freestream, so whatever numerical noise we have from the temporal integrator there is never damped. It shows up as unphysical streamwise vorticity streaks advecting toward the sphere (only with `cds`; `quick`'s built-in numerical dissipation masks them). I have confirmed it's the scheme, not the BC: reproduced with a plain `Simulation`, and in an inviscid periodic-box test where `cds`+RK2 grows grid-scale energy while `quick` decays it.

### Change
Add a small, strain-independent grid-scale dissipation via a blend
```julia
cds_blend(u,c,d) = (1-C_blend)*cds(u,c,d) + C_blend*quick(u,c,d)   # C_blend = 1/10
```
and use it for the visualization run. This removes the streaks while keeping the `cds` base; `C_blend=0` recovers pure `cds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)