### PR TITLE
Rename initial-condition keyword `uλ` → `u0`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ Recipe: flapping foil near a no-slip wall
 ## Constructor
 
 ```julia
-Simulation(dims, u_BC, L; ν, body, U=1, T=Float64, mem=Array, uλ=nothing,
+Simulation(dims, u_BC, L; ν, body, U=1, T=Float64, mem=Array, u0=nothing,
            g=nothing, perdir=(), exitBC=false, ϵ=1)
 ```
 
@@ -88,7 +88,7 @@ Simulation(dims, u_BC, L; ν, body, U=1, T=Float64, mem=Array, uλ=nothing,
 | `L` | Reference length in cells. Set `ν=U*L/Re`. |
 | `ν` | Kinematic viscosity. **Greek nu U+03BD — not Latin v.** Copy from examples. |
 | `T`, `mem` | Float type and array backend. GPU: `T=Float32, mem=CuArray` (NVIDIA) or `mem=ROCArray` (AMD). |
-| `uλ(i, xyz)` | Initial velocity; `i` is component index, `xyz` is position vector. See `ThreeD_TaylorGreenVortex.jl`. |
+| `u0(i, xyz)` | Initial velocity; `i` is component index, `xyz` is position vector. See `ThreeD_TaylorGreenVortex.jl`. |
 | `g(i, x, t)` | Spatially-uniform body force. See `TwoD_OscillatingFlowOverCircle.jl`. |
 | `perdir` | Tuple of periodic directions, e.g. `perdir=(1,2)`. |
 | `exitBC=true` | Convective outlet BC on the x-direction exit face. |
@@ -223,7 +223,7 @@ The default domain BCs are reflection with Neumann conditions for the tangential
 | `TwoD_Triangle.jl` | Custom analytic SDF |
 | `TwoD_UnicodePlots.jl` | Terminal-only visualisation |
 | `TwoD_Channel.jl` | Channel flow, periodic and body-force in x, no-slip in y |
-| `ThreeD_TaylorGreenVortex.jl` | 3D, `uλ` IC, `T=Float32`, GPU, GLMakie viz |
+| `ThreeD_TaylorGreenVortex.jl` | 3D, `u0` IC, `T=Float32`, GPU, GLMakie viz |
 | `ThreeD_Donut.jl` | 3D torus SDF, GPU, live Makie |
 | `ThreeD_Jelly.jl` | 3D moving body, GPU |
 | `ThreeD_HoverWriteVTK.jl` | 3D extruded sdf, VTK output |

--- a/Project.toml
+++ b/Project.toml
@@ -23,5 +23,8 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 WaterLily = "ed894a53-35f9-47f1-b17f-85db9237eebd"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
+[compat]
+WaterLily = "1.8"
+
 [sources]
 BiotSavartBCs = {url = "https://github.com/WaterLily-jl/BiotSavartBCs.jl"}

--- a/README.md
+++ b/README.md
@@ -79,20 +79,20 @@ A set of [flow metric functions](https://github.com/WaterLily-jl/WaterLily.jl/bl
 
 #### 3D Taylor Green Vortex
 
-The three-dimensional [Taylor Green Vortex](examples/ThreeD_TaylorGreenVortex.jl) demonstrates many of the other available simulation options. First, you can simulate a non-trivial initial velocity field by passing in a vector function `uλ(i,xyz)` where `i ∈ (1,2,3)` indicates the velocity component `uᵢ` and `xyz=[x,y,z]` is the position vector.
+The three-dimensional [Taylor Green Vortex](examples/ThreeD_TaylorGreenVortex.jl) demonstrates many of the other available simulation options. First, you can simulate a non-trivial initial velocity field by passing in a vector function `u0(i,xyz)` where `i ∈ (1,2,3)` indicates the velocity component `uᵢ` and `xyz=[x,y,z]` is the position vector.
 ```julia
 function TGV(L; Re=1600, U=1, T=Float32, mem=Array)
     # wavenumber, velocity
     κ, U = T(π/L), T(U)
     # Taylor-Green-Vortex initial velocity field
-    function uλ(i,xyz)
+    function u0(i,xyz)
         x,y,z = @. xyz*κ                       # scaled coordinates
         i==1 && return -U*sin(x)*cos(y)*cos(z) # u_x
         i==2 && return  U*cos(x)*sin(y)*cos(z) # u_y
         return zero(U)                         # u_z
     end
     # Initialize simulation
-    return Simulation((L, L, L), (0, 0, 0), L; U, uλ, ν = U*L/Re, T, mem)
+    return Simulation((L, L, L), (0, 0, 0), L; U, u0, ν = U*L/Re, T, mem)
 end
 ```
 This example also demonstrates the floating point type (`T=Float32`) and array memory type (`mem=Array`) options. For example, to run on an NVIDIA GPU we only need to import the [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl) library and initialize the `Simulation` memory on that device.

--- a/examples/ThreeD_TaylorGreenVortex.jl
+++ b/examples/ThreeD_TaylorGreenVortex.jl
@@ -5,14 +5,14 @@ function TGV(L; Re=1600, U=1, T=Float32, mem=Array)
     # Domain has length = π to take advantage of symmetry conditions
     κ, U = T(π/L), T(U)
     # Taylor-Green-Vortex initial velocity field
-    function uλ(i,xyz)
+    function u0(i,xyz)
         x,y,z = @. xyz*κ                       # scaled coordinates
         i==1 && return -U*sin(x)*cos(y)*cos(z) # u_x
         i==2 && return  U*cos(x)*sin(y)*cos(z) # u_y
         return zero(U)                         # u_z
     end
     # Initialize simulation
-    return Simulation((L, L, L), (0, 0, 0), L; U, uλ, ν = U*L/Re, T, mem)
+    return Simulation((L, L, L), (0, 0, 0), L; U, u0, ν = U*L/Re, T, mem)
 end
 
 function λ₂!(arr, sim)                          # compute log10(-λ₂)


### PR DESCRIPTION
Adapt to the new WaterLily initial condition keyword change https://github.com/WaterLily-jl/WaterLily.jl/pull/303. Note that users receive a deprecation warning when still using `uλ` instead of `u0`. The full deprecation is planned for WaterLily 2.0.