### PR TITLE
Adapt examples to WaterLily #301 (λ set at construction)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,4 +24,4 @@ WaterLily = "ed894a53-35f9-47f1-b17f-85db9237eebd"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [sources]
-BiotSavartBCs = {url = "https://github.com/weymouth/BiotSavartBCs.jl"}
+BiotSavartBCs = {url = "https://github.com/WaterLily-jl/BiotSavartBCs.jl"}

--- a/examples/ThreeD_SphereLESBiotSavart.jl
+++ b/examples/ThreeD_SphereLESBiotSavart.jl
@@ -22,9 +22,9 @@ function read_forces(fname)
     return obj["force"], obj["t"]
 end
 # Sphere
-function sphere(m; n=5m÷2, R=m÷3, U=1, Re=3700, T=Float32, mem=CuArray)
+function sphere(m; n=5m÷2, R=m÷3, U=1, Re=3700, T=Float32, mem=CuArray, λ=quick)
     body = AutoBody((x,t)->√sum(abs2,x .- m÷2)-R)
-    BiotSimulation((n,m,m), (U,0,0), 2R; ν=U*2R/Re, body, T, mem)
+    BiotSimulation((n,m,m), (U,0,0), 2R; ν=U*2R/Re, body, T, mem, λ)  # convective scheme set at construction (WaterLily #301)
 end
 # Metrics
 recirculation_length(U) = findfirst(axes(U,1)) do i
@@ -32,7 +32,7 @@ recirculation_length(U) = findfirst(axes(U,1)) do i
 end |> i -> (i- m÷2)/2R
 
 function run_sim(p; m=3*2^p, R=m÷3, U=1, Re=3700, mem=CuArray, T=Float32, restart=nothing, restart_stats=nothing, restart_force=nothing)
-    sim = sphere(m; R, U, Re, T, mem)
+    sim = sphere(m; R, U, Re, T, mem, λ)
     S = zeros(T, size(sim.flow.p)..., ndims(sim.flow.p), ndims(sim.flow.p)) |> mem # working array holding a tensor for each cell
     force, t = Vector{T}[] ,T[] # force coefficients, time
 
@@ -40,7 +40,7 @@ function run_sim(p; m=3*2^p, R=m÷3, U=1, Re=3700, mem=CuArray, T=Float32, resta
         load!(sim; fname=restart)
         println("Loaded: $restart")
     end
-    sim_step!(sim, stats_init; remeasure=false, verbose=true, λ, udf, νₜ=smagorinsky, S, Cs, Δ)
+    sim_step!(sim, stats_init; remeasure=false, verbose=true, udf, νₜ=smagorinsky, S, Cs, Δ)
 
     meanflow = MeanFlow(sim.flow; uu_stats=true)
     if !isnothing(restart_stats)
@@ -56,7 +56,7 @@ function run_sim(p; m=3*2^p, R=m÷3, U=1, Re=3700, mem=CuArray, T=Float32, resta
 
     next_save = sim_time(sim) + save_interval
     while sim_time(sim) < time_max
-        sim_step!(sim, sim_time(sim)+stats_interval; remeasure=false, verbose=false, λ, udf, νₜ=smagorinsky, S, Cs, Δ)
+        sim_step!(sim, sim_time(sim)+stats_interval; remeasure=false, verbose=false, udf, νₜ=smagorinsky, S, Cs, Δ)
         sim_info(sim)
 
         WaterLily.update!(meanflow, sim.flow)
@@ -104,7 +104,7 @@ function main(;load_time=nothing)
         return run_sim(p; m, R, U, mem, Re, T, restart, restart_stats, restart_force)
     else
         t_str = @sprintf("%i", load_time)
-        sim = sphere(m; R, U, Re, T, mem)
+        sim = sphere(m; R, U, Re, T, mem, λ)
         fname = "$(fname_save)_t$(t_str).jld2"
         load!(sim; fname)
         println("Loaded: $fname")
@@ -130,7 +130,7 @@ viz!(sim) # 3D
 viz!(sim; d=2) # 2D
 # Run and visualize
 S = zeros(T, size(sim.flow.p)..., ndims(sim.flow.p), ndims(sim.flow.p)) |> mem
-viz!(sim;duration=10,remeasure=false,λ,udf,udf_kwargs=(:S=>S,:νₜ=>smagorinsky,:Cs=>Cs,:Δ=>Δ))
+viz!(sim;duration=10,remeasure=false,udf,udf_kwargs=(:S=>S,:νₜ=>smagorinsky,:Cs=>Cs,:Δ=>Δ))
 
 # Visualize the meanflow
 viz!(sim, meanflow.U[:,:,:,1]; d=2, levels=20)

--- a/examples/ThreeD_SphereLESBiotSavart.jl
+++ b/examples/ThreeD_SphereLESBiotSavart.jl
@@ -24,7 +24,7 @@ end
 # Sphere
 function sphere(m; n=5m÷2, R=m÷3, U=1, Re=3700, T=Float32, mem=CuArray, λ=quick)
     body = AutoBody((x,t)->√sum(abs2,x .- m÷2)-R)
-    BiotSimulation((n,m,m), (U,0,0), 2R; ν=U*2R/Re, body, T, mem, λ)  # convective scheme set at construction (WaterLily #301)
+    BiotSimulation((n,m,m), (U,0,0), 2R; ν=U*2R/Re, body, T, mem, λ)
 end
 # Metrics
 recirculation_length(U) = findfirst(axes(U,1)) do i

--- a/examples/TwoD_Channel.jl
+++ b/examples/TwoD_Channel.jl
@@ -8,7 +8,7 @@ function channel_BC!(u)
 end
 
 import WaterLily: mom_step!,mom_predict!,mom_correct!,mom_project!,scale_u!,CFL,AbstractFlow
-# overwrite mom_step! to inject channel BC after each BC! call (convective scheme is flow.λ, set at construction)
+# overwrite mom_step! to inject channel BC after each BC! call
 @fastmath function mom_step!(a::AbstractFlow,b::AbstractPoisson;udf=nothing,kwargs...)
     a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
     # predictor u → u'

--- a/examples/TwoD_Channel.jl
+++ b/examples/TwoD_Channel.jl
@@ -7,15 +7,15 @@ function channel_BC!(u)
     @loop u[I,1] = -u[I+δ(2,I),1] over I ∈ slice(N,1,2)
 end
 
-import WaterLily: mom_step!,mom_predict!,mom_correct!,mom_project!,scale_u!,CFL,AbstractFlow,quick
-# overwrite mom_step! to inject channel BC after each BC! call
-@fastmath function mom_step!(a::AbstractFlow,b::AbstractPoisson;λ=quick,udf=nothing,kwargs...)
+import WaterLily: mom_step!,mom_predict!,mom_correct!,mom_project!,scale_u!,CFL,AbstractFlow
+# overwrite mom_step! to inject channel BC after each BC! call (convective scheme is flow.λ, set at construction)
+@fastmath function mom_step!(a::AbstractFlow,b::AbstractPoisson;udf=nothing,kwargs...)
     a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
     # predictor u → u'
-    mom_predict!(a,t₀,t₁;λ,udf,kwargs...); channel_BC!(a.u)
+    mom_predict!(a,t₀,t₁;udf,kwargs...); channel_BC!(a.u)
     mom_project!(a,b,1,t₁); channel_BC!(a.u)
     # corrector u → u¹
-    mom_correct!(a,t₁;λ,udf,kwargs...); channel_BC!(a.u)
+    mom_correct!(a,t₁;udf,kwargs...); channel_BC!(a.u)
     mom_project!(a,b,0.5,t₁); channel_BC!(a.u)
     push!(a.Δt,CFL(a))
 end

--- a/examples/TwoD_LidCavity.jl
+++ b/examples/TwoD_LidCavity.jl
@@ -10,15 +10,15 @@ function lid_BC!(u)
     @loop u[I,2] = -u[I+δ(1,I),2] over I ∈ slice(N,1,1)
 end
 
-import WaterLily: mom_step!,mom_predict!,mom_correct!,mom_project!,scale_u!,CFL,AbstractFlow,quick
-# overwrite mom_step! to inject lid BC after each BC! call
-@fastmath function mom_step!(a::AbstractFlow,b::AbstractPoisson;λ=quick,udf=nothing,kwargs...)
+import WaterLily: mom_step!,mom_predict!,mom_correct!,mom_project!,scale_u!,CFL,AbstractFlow
+# overwrite mom_step! to inject lid BC after each BC! call (convective scheme is flow.λ, set at construction)
+@fastmath function mom_step!(a::AbstractFlow,b::AbstractPoisson;udf=nothing,kwargs...)
     a.u⁰ .= a.u; scale_u!(a,0); t₁ = sum(a.Δt); t₀ = t₁-a.Δt[end]
     # predictor u → u'
-    mom_predict!(a,t₀,t₁;λ,udf,kwargs...); lid_BC!(a.u)
+    mom_predict!(a,t₀,t₁;udf,kwargs...); lid_BC!(a.u)
     mom_project!(a,b,1,t₁); lid_BC!(a.u)
     # corrector u → u¹
-    mom_correct!(a,t₁;λ,udf,kwargs...); lid_BC!(a.u)
+    mom_correct!(a,t₁;udf,kwargs...); lid_BC!(a.u)
     mom_project!(a,b,0.5,t₁); lid_BC!(a.u)
     push!(a.Δt,CFL(a))
 end


### PR DESCRIPTION
https://github.com/WaterLily-jl/WaterLily.jl/pull/301 moved the convective scheme `λ` from a `sim_step!`/`mom_step!`/`viz!` keyword to the `Simulation`/`Flow` constructor (stored as `flow.λ`).

- **`ThreeD_SphereLESBiotSavart.jl`**: pass `λ` to `BiotSimulation` in `sphere()`; drop `λ` from the two `sim_step!` calls and the `viz!` call (`udf` and its kwargs are unchanged). Also repoints the `[sources]` BiotSavartBCs to `WaterLily-jl/BiotSavartBCs.jl` (the refactored, #301-compatible repo).
- **`TwoD_Channel.jl`, `TwoD_LidCavity.jl`**: the custom `mom_step!` overrides drop the `λ` keyword and the `λ` argument to `mom_predict!`/`mom_correct!` (scheme is now `flow.λ`).

**Verified against WaterLily master:** a CPU `BiotSimulation(...; λ=cds)` + `udf=sgs!` runs finite with `flow.λ===cds`, and the custom-`mom_step!` channel pattern runs finite.

Notes:
- `Manifest.toml` needs regenerating once #301 WaterLily is tagged/registered (it currently locks an older WaterLily + the old BiotSavartBCs).
- Overlaps #36 (`fix-sphere-les-cds`, adds `cds_blend`) which touches the same sphere file — reconcile/rebase one onto the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)